### PR TITLE
fix completion if compiled only with +python3

### DIFF
--- a/python.vim
+++ b/python.vim
@@ -3,7 +3,7 @@
 " Maintainer:	Tom Picton <tom@tompicton.co.uk>
 " Previous Maintainer: James Sully <sullyj3@gmail.com>
 " Previous Maintainer: Johannes Zellner <johannes@zellner.org>
-" Last Change:	Thur, 09 November 2017
+" Last Change:	Wed, 20 December 2017
 " https://github.com/tpict/vim-ftplugin-python
 
 if exists("b:did_ftplugin") | finish | endif
@@ -20,6 +20,9 @@ setlocal comments=b:#,fb:-
 setlocal commentstring=#\ %s
 
 setlocal omnifunc=pythoncomplete#Complete
+if has('python3')
+       setlocal omnifunc=python3complete#Complete
+endif
 
 set wildignore+=*.pyc
 


### PR DESCRIPTION
In Debian, the default vim version is not compiled with `+python`, but with `+python3`. In this case, `pythoncomplete#Complete()` will throw an error as it depends on `+python`. However, we can use `python3complete#Complete()` if `+python3` is available.  

If no Python support was compiled in, `pythoncomplete#Complete()` will still be used and still throw an error, so the user is warned in this case.