### PR TITLE
runtime: fix python includeexpr

### DIFF
--- a/python.vim
+++ b/python.vim
@@ -14,7 +14,7 @@ set cpo&vim
 setlocal cinkeys-=0#
 setlocal indentkeys-=0#
 setlocal include=^\\s*\\(from\\\|import\\)
-setlocal includeexpr=substitute(v:fname,'\\.','/','g')
+setlocal includeexpr=substitute(substitute(v:fname,'\\(.\\)\\.','\\1/','g'),'\\.','','g')
 setlocal suffixesadd=.py
 setlocal comments=b:#,fb:-
 setlocal commentstring=#\ %s

--- a/python.vim
+++ b/python.vim
@@ -3,7 +3,7 @@
 " Maintainer:	Tom Picton <tom@tompicton.co.uk>
 " Previous Maintainer: James Sully <sullyj3@gmail.com>
 " Previous Maintainer: Johannes Zellner <johannes@zellner.org>
-" Last Change:	Wed, 20 December 2017
+" Last Change:	Sat, 17 March 2018
 " https://github.com/tpict/vim-ftplugin-python
 
 if exists("b:did_ftplugin") | finish | endif


### PR DESCRIPTION
Python includes can have leading `.` for includes relative to the cwd.
They were previously substituted with `/`, which is incorrect.
Now they are replaced with `./`.