### PR TITLE
Retain omnifunc if exists

### DIFF
--- a/python.vim
+++ b/python.vim
@@ -37,10 +37,10 @@ setlocal suffixesadd=.py
 setlocal comments=b:#,fb:-
 setlocal commentstring=#\ %s
 
-" Do not overwrite existing omnifunc
-if &omnifunc == ''
-  if has('python') | setlocal omnifunc=pythoncomplete#Complete | endif
-  if has('python3') | setlocal omnifunc=python3complete#Complete | endif
+if has('python3')
+  setlocal omnifunc=python3complete#Complete 
+elseif has('python')
+  setlocal omnifunc=pythoncomplete#Complete
 endif
 
 set wildignore+=*.pyc

--- a/python.vim
+++ b/python.vim
@@ -3,7 +3,7 @@
 " Maintainer:	Tom Picton <tom@tompicton.co.uk>
 " Previous Maintainer: James Sully <sullyj3@gmail.com>
 " Previous Maintainer: Johannes Zellner <johannes@zellner.org>
-" Last Change:	Sun, 15 April 2018
+" Last Change:	Tue, 26 June 2018
 " https://github.com/tpict/vim-ftplugin-python
 
 if exists("b:did_ftplugin") | finish | endif
@@ -37,9 +37,10 @@ setlocal suffixesadd=.py
 setlocal comments=b:#,fb:-
 setlocal commentstring=#\ %s
 
-setlocal omnifunc=pythoncomplete#Complete
-if has('python3')
-       setlocal omnifunc=python3complete#Complete
+" Do not overwrite existing omnifunc
+if &omnifunc == ''
+  if has('python') | setlocal omnifunc=pythoncomplete#Complete | endif
+  if has('python3') | setlocal omnifunc=python3complete#Complete | endif
 endif
 
 set wildignore+=*.pyc


### PR DESCRIPTION
As discussed [here](https://github.com/sullyj3/vim-ftplugin-python/issues/9):
If one sets a custom omnifunc for python, it will be overwritten by this ftplugin. Using the changes of this pull-request, we do not overwrite the `omnifunc` if it exists. Plus, we check for both python and python3 before setting the `omnifunc` to prevent errors in vim versions with neither python nor python3 support.