### PR TITLE
RFC Use Python 3 pydoc where possible

### DIFF
--- a/python.vim
+++ b/python.vim
@@ -3,7 +3,7 @@
 " Maintainer:	Tom Picton <tom@tompicton.co.uk>
 " Previous Maintainer: James Sully <sullyj3@gmail.com>
 " Previous Maintainer: Johannes Zellner <johannes@zellner.org>
-" Last Change:	Sun 17 Mar 2019
+" Last Change:	Thur 25 April 2019
 " https://github.com/tpict/vim-ftplugin-python
 
 if exists("b:did_ftplugin") | finish | endif
@@ -118,7 +118,11 @@ if !exists("g:python_recommended_style") || g:python_recommended_style != 0
     setlocal expandtab shiftwidth=4 softtabstop=4 tabstop=8
 endif
 
-" Use pydoc for keywordprg
+" Use pydoc for keywordprg.
+" Unix users preferentially get pydoc3, then pydoc2.
+" Windows doesn't have a standalone pydoc executable in $PATH by default, nor
+" does it have separate python2/3 executables, so Windows users just get
+" whichever version corresponds to their installed Python version.
 if executable('python3')
   setlocal keywordprg=python3\ -m\ pydoc
 elseif executable('python')

--- a/python.vim
+++ b/python.vim
@@ -38,7 +38,7 @@ setlocal comments=b:#,fb:-
 setlocal commentstring=#\ %s
 
 if has('python3')
-  setlocal omnifunc=python3complete#Complete 
+  setlocal omnifunc=python3complete#Complete
 elseif has('python')
   setlocal omnifunc=pythoncomplete#Complete
 endif
@@ -118,32 +118,11 @@ if !exists("g:python_recommended_style") || g:python_recommended_style != 0
     setlocal expandtab shiftwidth=4 softtabstop=4 tabstop=8
 endif
 
-" First time: try finding "pydoc".
-if !exists('g:pydoc_executable')
-    if executable('pydoc')
-        let g:pydoc_executable = 1
-    else
-        let g:pydoc_executable = 0
-    endif
-endif
-
-" Windows-specific pydoc setup
-if has('win32') || has('win64')
-    if executable('python')
-        " available as Tools\scripts\pydoc.py
-        let g:pydoc_executable = 1
-    else
-        let g:pydoc_executable = 0
-    endif
-endif
-
-" If "pydoc" was found use it for keywordprg.
-if g:pydoc_executable
-    if has('win32') || has('win64')
-        setlocal keywordprg=python\ -m\ pydoc\ 
-    else
-        setlocal keywordprg=pydoc
-    endif
+" Use pydoc for keywordprg
+if executable('python3')
+  setlocal keywordprg=python3\ -m\ pydoc\ 
+elseif executable('python')
+  setlocal keywordprg=python\ -m\ pydoc\ 
 endif
 
 " Script for filetype switching to undo the local stuff we may have changed

--- a/python.vim
+++ b/python.vim
@@ -120,9 +120,9 @@ endif
 
 " Use pydoc for keywordprg
 if executable('python3')
-  setlocal keywordprg=python3\ -m\ pydoc\ 
+  setlocal keywordprg=python3\ -m\ pydoc
 elseif executable('python')
-  setlocal keywordprg=python\ -m\ pydoc\ 
+  setlocal keywordprg=python\ -m\ pydoc
 endif
 
 " Script for filetype switching to undo the local stuff we may have changed


### PR DESCRIPTION
Close #10 

I'm going to leave this open for comment for a week or two to get feedback as I've simplified the setting of `keywordprg`. AFAIK pydoc is included with Python so we can assume that the user has it and call it using the appropriate version of Python with the `-m` flag, which spares us from a little platform-specific logic.

I'm not sure if/why Windows needs a trailing space on `keywordprg`. Can any Windows users comment?