### PR TITLE
Useful default define value

### DIFF
--- a/python.vim
+++ b/python.vim
@@ -14,6 +14,7 @@ set cpo&vim
 setlocal cinkeys-=0#
 setlocal indentkeys-=0#
 setlocal include=^\\s*\\(from\\\|import\\)
+setlocal define=^\\s*\\(def\\\|class\\)
 
 " For imports with leading .., append / and replace additional .s with ../
 let b:grandparent_match = '^\(.\.\)\(\.*\)'


### PR DESCRIPTION
'define' value is not set by default, so set it to something useful. 'define' value used in many commands like [i and [d.