### PR TITLE
Fix shiftwidth configuration

### DIFF
--- a/python.vim
+++ b/python.vim
@@ -3,7 +3,7 @@
 " Maintainer:	Tom Picton <tom@tompicton.co.uk>
 " Previous Maintainer: James Sully <sullyj3@gmail.com>
 " Previous Maintainer: Johannes Zellner <johannes@zellner.org>
-" Last Change:	Fri, 20 March 2020
+" Last Change:	Mon, 5 October 2020
 " https://github.com/tpict/vim-ftplugin-python
 
 if exists("b:did_ftplugin") | finish | endif
@@ -116,7 +116,7 @@ endif
 
 if !exists("g:python_recommended_style") || g:python_recommended_style != 0
     " As suggested by PEP8.
-    setlocal expandtab shiftwidth=4 softtabstop=4 tabstop=8
+    setlocal expandtab tabstop=4 softtabstop=4 shiftwidth=4
 endif
 
 " Use pydoc for keywordprg.


### PR DESCRIPTION
PEP8 doesn't tell anything about 8 spaces indentation anywhere, tabstop should be 4 instead of 8 (without it removing indentation with backspace doesn't work. Also I'm setting shiftwidth to 0 because it makes indentation easier to configure. To quote `:h shiftwidth`:

> Returns the effective value of 'shiftwidth'. This is the 'shiftwidth' value unless it is zero, in which case it is the 'tabstop' value. 