### PR TITLE
Basic matchit support

### DIFF
--- a/python.vim
+++ b/python.vim
@@ -28,9 +28,11 @@ let b:parent_sub = './'
 let b:child_match = '\(\w\)\.\(\w\)'
 let b:child_sub = '\1/\2'
 
-" Support for built-in "matchit" plugin
-let b:match_words = '\<if\>:\<elif\>:\<else\>'
-let b:match_skip  = 'R:^\s*'
+" Matchit support
+if exists('loaded_matchit') && !exists('b:match_words')
+  let b:match_words = '\<if\>:\<elif\>:\<else\>'
+  let b:match_skip = 'R:^\s*'
+endif
 
 setlocal includeexpr=substitute(substitute(substitute(
       \v:fname,

--- a/python.vim
+++ b/python.vim
@@ -28,6 +28,10 @@ let b:parent_sub = './'
 let b:child_match = '\(\w\)\.\(\w\)'
 let b:child_sub = '\1/\2'
 
+" Support for built-in "matchit" plugin
+let b:match_words = '\<if\>:\<elif\>:\<else\>'
+let b:match_skip  = 'R:^\s*'
+
 setlocal includeexpr=substitute(substitute(substitute(
       \v:fname,
       \b:grandparent_match,b:grandparent_sub,''),
@@ -173,6 +177,8 @@ let b:undo_ftplugin = 'setlocal cinkeys<'
       \ . '|unlet! b:child_sub'
       \ . '|unlet! b:grandparent_match'
       \ . '|unlet! b:grandparent_sub'
+      \ . '|unlet! b:match_skip'
+      \ . '|unlet! b:match_words'
       \ . '|unlet! b:next'
       \ . '|unlet! b:next_end'
       \ . '|unlet! b:next_endtoplevel'


### PR DESCRIPTION
Matchit is a built-in plugin that allows the `%` key to jump between language constructs. This PR adds support for jumping between if, elif and else:

``` python
if one:
    print("foo")
elif two:
    print("bar")
else:
    print("baz")
```

It's pretty basic -- there are lots of other constructs that this could be useful for. But it's at least a start. Here's what the Ruby support uses: https://github.com/vim-ruby/vim-ruby/blob/4788a08433c3c90e131fc7d110d82577e1234a86/ftplugin/ruby.vim#L21-L41