### PR TITLE
Add optional 'async' before 'def' in define

### DIFF
--- a/python.vim
+++ b/python.vim
@@ -14,7 +14,7 @@ set cpo&vim
 setlocal cinkeys-=0#
 setlocal indentkeys-=0#
 setlocal include=^\\s*\\(from\\\|import\\)
-setlocal define=^\\s*\\(def\\\|class\\)
+setlocal define=^\\s*\\([async ]\\?def\\\|class\\)
 
 " For imports with leading .., append / and replace additional .s with ../
 let b:grandparent_match = '^\(.\.\)\(\.*\)'


### PR DESCRIPTION
Previous regex would catch line starting with `def` or `class`, but not `async def`. This patch lets an optional `async ` come before a `def`.